### PR TITLE
Update ReaderSTEP.cpp

### DIFF
--- a/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
@@ -174,7 +174,7 @@ void ReaderSTEP::loadModelFromFile( const std::wstring& filePath, shared_ptr<Bui
 	infile.seekg( 0, std::ios::beg );
 
 	// read file content into string
-	std::string buffer( (int)file_size, '\0' );
+	std::string buffer( (size_t)file_size, '\0' );
 	infile.read( &buffer[0], file_size );
 	infile.close();
 


### PR DESCRIPTION
Q:I cannot load a big IFC file ( about 2.0GB) by SimpleViewerExampleQt.
A:I find the size of IFC file is out of the range(type:int).therefore, the datatype is modified to the datatype of size_t and can solve the little bug.
If you think it is reasonable and feasible, you can directly your code :).